### PR TITLE
Towards supporting inductive types

### DIFF
--- a/examples/test.ml
+++ b/examples/test.ml
@@ -28,7 +28,7 @@ type point = {
   color: color;
 }
 
-let ty_point = Ty.(
+let ty_point : point Ty.ty = Ty.(
   let f_x = mk_field "x" ~ty:Int ~get:(fun r->r.x) in
   let f_y = mk_field "y" ~ty:Int ~get:(fun r->r.y) in
   let f_c = mk_field "color" ~ty:ty_color ~get:(fun r->r.color) in
@@ -46,3 +46,21 @@ let () =
     ; {x=0; y=42; color=Blue }
     ]
 
+
+(* Testing induction *)
+
+type nat = O | S of nat
+
+let ty_nat = Ty.(
+  let v_O = mk_variant "O" ~args:TNil ~make:(fun HNil -> O) in
+  let v_S = mk_variant "O" ~args:(TCons (Rec,TNil)) ~make:(fun (HCons (n,HNil)) -> S n) in
+  Sum {
+    sum_name="nat";
+    sum_variants=VCons (v_O, VCons (v_S, VNil));
+    sum_match=fun
+      (VM_cons (f_O, VM_cons (f_S, VM_nil))) v ->
+        match v with
+        | O -> f_O HNil
+        | S n -> f_S (HCons(n,HNil))
+  }
+)

--- a/src/ty.mli
+++ b/src/ty.mli
@@ -2,64 +2,65 @@
 (** {1 Representation of OCaml types *)
 
 (** Description of type ['a] *)
-type 'a ty =
-  | Unit : unit ty
-  | Int : int ty
-  | Bool : bool ty
-  | List : 'a ty -> 'a list ty
-  | Sum : ('s, 'v) sum -> 's ty
-  | Record : ('r, 'fields) record -> 'r ty
-  | Tuple : ('t, 'a) tuple -> 't ty
-  | Lazy : 'a ty -> 'a Lazy.t ty
-  | Fun : 'a ty * 'b ty -> ('a -> 'b) ty
+type ('a,'x) rty =
+  | Rec : ('x,'x) rty
+  | Unit : (unit,'x) rty
+  | Int : (int,'x) rty
+  | Bool : (bool,'x) rty
+  | List : ('a,'x) rty -> ('a list,'x) rty
+  | Sum : ('s, 'v, 'x) sum -> ('s,'x) rty
+  | Record : ('r, 'fields, 'x) record -> ('r,'x) rty
+  | Tuple : ('t, 'a, 'x) tuple -> ('t,'x) rty
+  | Lazy : ('a,'x) rty -> ('a Lazy.t,'x) rty
+  | Fun : ('a,'x) rty * ('b,'x) rty -> ('a -> 'b, 'x) rty
 
 and 'a hlist =
   | HNil : unit hlist
   | HCons : 'a * 'b hlist -> ('a * 'b) hlist
 
 (** Description of list of types *)
-and 'a ty_list =
-  | TNil : unit ty_list
-  | TCons : 'a ty * 'b ty_list -> ('a * 'b) ty_list
+and ('a,'x) ty_list =
+  | TNil : (unit,'x) ty_list
+  | TCons : ('a,'x) rty * ('b,'x) ty_list -> ('a * 'b,'x) ty_list
 
 (** Sum type ['s] *)
-and ('s, 'v) sum = {
+and ('s, 'v, 'x) sum = {
   sum_name : string;
-  sum_variants : ('s, 'v) variant_list;
-  sum_match : 'ret. ('s, 'v, 'ret) variant_match -> 's -> 'ret;
+  sum_variants : ('s, 'v, 'x) variant_list;
+  sum_match : 'ret. ('s, 'v, 'x, 'ret) variant_match -> 's -> 'ret;
 }
 
 (** List of variants for the sum type ['s] *)
-and ('s, 'v) variant_list =
-  | VNil : ('s, unit) variant_list
-  | VCons : ('s, 'a) variant * ('s, 'b) variant_list -> ('s, 'a * 'b) variant_list
+and ('s, 'v, 'x) variant_list =
+  | VNil : ('s, unit, 'x) variant_list
+  | VCons : ('s, 'a, 'x) variant * ('s, 'b, 'x) variant_list -> ('s, 'a * 'b, 'x) variant_list
 
 (** Pattern matching encoding on sums *)
-and ('s, 'v, 'ret) variant_match =
-  | VM_nil : ('s, unit, 'ret) variant_match
-  | VM_cons : ('a hlist -> 'ret) * ('s, 'b, 'ret) variant_match -> ('s, 'a * 'b, 'ret) variant_match
+and ('s, 'v, 'x, 'ret) variant_match =
+  | VM_nil : ('s, unit, 'x, 'ret) variant_match
+  | VM_cons : ('a hlist -> 'ret) * ('s, 'b, 'x, 'ret) variant_match -> ('s, 'a * 'b, 'x, 'ret) variant_match
 
 (** A variant of the sum type ['s] *)
-and ('s, 'a) variant = {
+and ('s, 'a, 'x) variant = {
   variant_name : string;
-  variant_args : 'a ty_list;
+  variant_args : ('a,'x) ty_list;
   variant_make : 'a hlist -> 's;
 }
 
 (** Description of record of type ['r] with fields ['fields] *)
-and ('r, 'fields) record = {
+and ('r, 'fields, 'x) record = {
   record_name : string;
-  record_args : ('r, 'fields) field_list;
+  record_args : ('r, 'fields, 'x) field_list;
   record_make : 'fields hlist -> 'r;  (* build record *)
 }
 
-and (_, _) field_list =
-  | RNil : ('r, unit) field_list
-  | RCons : ('r, 'a) field * ('r, 'b) field_list -> ('r, 'a * 'b) field_list
+and (_, _, _) field_list =
+  | RNil : ('r, unit, 'x) field_list
+  | RCons : ('r, 'a, 'x) field * ('r, 'b, 'x) field_list -> ('r, 'a * 'b, 'x) field_list
 
-and ('r, 'a) field = {
+and ('r, 'a, 'x) field = {
   field_name : string;
-  field_ty : 'a ty;
+  field_ty : ('a,'x) rty;
   field_get : 'r -> 'a;
   field_set : ('a -> 'r) option; (* None if field immutable *)
 }
@@ -68,27 +69,30 @@ and ('r, 'a) field = {
     For instance we would have
     [((int * bool * float), (int * (bool * (float * unit)))) tuple]
 *)
-and ('t, 'a) tuple = {
-  tuple_args : 'a ty_list;
+and ('t, 'a, 'x) tuple = {
+  tuple_args : ('a,'x) ty_list;
   tuple_get : 't -> 'a hlist;
   tuple_make : 'a hlist -> 't;
 }
 
+type 'a ty = ('a,'a) rty
+
+
 (** {2 Helpers} *)
 
-val mk_field : ?set:('a -> 'r) -> string -> ty:'a ty -> get:('r -> 'a) -> ('r, 'a) field
-val mk_variant : string -> args:'a ty_list -> make:('a hlist -> 's) -> ('s, 'a) variant
+val mk_field : ?set:('a -> 'r) -> string -> ty:('a,'x) rty -> get:('r -> 'a) -> ('r, 'a, 'x) field
+val mk_variant : string -> args:('a,'x) ty_list -> make:('a hlist -> 's) -> ('s, 'a, 'x) variant
 
 val int : int ty
 val bool : bool ty
 val unit : unit ty
-val option : 'a ty -> 'a option ty
-val list : 'a ty -> 'a list ty
-val lazy_ : 'a ty -> 'a Lazy.t ty
-val ref : 'a ty -> 'a ref ty
+val option : ('a,'x) rty -> ('a option,'x) rty
+val list : ('a,'x) rty -> ('a list,'x) rty
+val lazy_ : ('a,'x) rty -> ('a Lazy.t,'x) rty
+val ref : ('a,'x) rty -> ('a ref,'x) rty
 
-val pair : 'a ty -> 'b ty -> ('a * 'b) ty
-val triple : 'a ty -> 'b ty -> 'c ty -> ('a * 'b * 'c) ty
+val pair : ('a,'x) rty -> ('b,'x) rty -> ('a * 'b,'x) rty
+val triple : ('a,'x) rty -> ('b,'x) rty -> ('c,'x) rty -> ('a * 'b * 'c,'x) rty
 
 (** {2 Generic functions} *)
 


### PR DESCRIPTION
I noticed an oversight earlier: inductive types. I tried adding them, though that isn't free. There is no support for mutual recursion, just one `Rec` parameter whose type must be threaded through all constructor. So it's kind of boring.

It breaks the existing tests though, and I'm not quite sure why. I haven't had time to investigate, so I'm just putting the code here for discussion/scrutiny.
